### PR TITLE
Added the option to disable live mode and preview.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ You can use this project by including it in your package.json, then including th
 
 #### Ensure that you have webpack installed
 `npm install -g webpack`
+`npm install webpack-dev-server -g`
 
 #### Get the code
 Run the following:

--- a/src/jsx/file_browser.jsx
+++ b/src/jsx/file_browser.jsx
@@ -53,7 +53,7 @@ class FileBrowser extends React.Component {
     this.props.onChangeFile(this.state.files[0])
   }
 
-  // List what files we have
+  // List what text files we have
   listManuscript() {
     this.busy(true);
     FileAccessor.listFiles((error, files) => {
@@ -66,7 +66,7 @@ class FileBrowser extends React.Component {
     });
   }
 
-  // List what files we have
+  // List what image files we have
   listImage() {
     this.busy(true);
     FileAccessor.listImages((error, files) => {
@@ -79,7 +79,7 @@ class FileBrowser extends React.Component {
     });
   }
 
-  // List what files we have
+  // List what code files we have
   listCode() {
     this.busy(true);
     FileAccessor.listCode((error, files) => {

--- a/src/jsx/main.jsx
+++ b/src/jsx/main.jsx
@@ -20,7 +20,7 @@ class Main extends React.Component {
       currentFile: null,
       imageFile: null,
       previewState: 'closed',
-      inLiveMode: true,
+      inLiveMode: this.props.options.enablePreview,
       previewHtml: ""
     }
 
@@ -44,8 +44,9 @@ class Main extends React.Component {
 
   // Lifecycle methods
   componentDidMount() {
-    // Trigger a preview right away -- since we start in live mode
-    this.onGeneratePreview();
+    // Trigger a preview right away if we are in live mode
+    if (this.state.inLiveMode)
+      this.onGeneratePreview();
   }
 
   // File event operations
@@ -116,6 +117,7 @@ class Main extends React.Component {
           onGeneratePreview={this.onGeneratePreview}
           toggleLiveMode={this.toggleLiveMode}
           inLiveMode={this.state.inLiveMode}
+          enablePreview={this.props.options.enablePreview}
         />
         <section className="main-view">
           <section className={this.getWorkspaceClass()}>
@@ -129,7 +131,7 @@ class Main extends React.Component {
             { this.state.inLiveMode ? <LivePreview key='live-mode' ref="liveMode" html={this.state.previewHtml} previewState={this.state.previewState} previewErrors={this.state.previewErrors} /> : null }
           </section>
         </section>
-        { this.state.inLiveMode ? <span /> : <Preview key='preview' onClosePreview={this.onClosePreview} html={this.state.previewHtml} previewState={this.state.previewState} previewErrors={this.state.previewErrors} /> }
+        { this.state.inLiveMode ? <span /> : <Preview key='preview' inLiveMode={this.state.inLiveMode} onClosePreview={this.onClosePreview} html={this.state.previewHtml} previewState={this.state.previewState} previewErrors={this.state.previewErrors} /> }
         { this.state.imageFile ? <ImageModal file={this.state.imageFile} onClose={ _.partial(this.onPreviewImage, null) } /> : null }
       </section>
     );

--- a/src/jsx/toolbar.jsx
+++ b/src/jsx/toolbar.jsx
@@ -2,19 +2,26 @@ import React from "react";
 
 class Toolbar extends React.Component {
   render() {
-    return (
-      <nav className="toolbar">
-        <h3 className="book-title">{ this.props.bookTitle}</h3>
-        <ul className="actions">
-          <li><a className={this.props.inLiveMode ? 'active' : '' } onClick={this.props.toggleLiveMode}><i className="fa fa-columns"></i> Live Mode</a></li>
-          <li><a className={this.props.inLiveMode ? 'disabled' : ''} onClick={this.props.onGeneratePreview}><i className="fa fa-play"></i> Preview</a></li>
-        </ul>
-      </nav>
-    );
+    if (this.props.enablePreview) {
+      return (
+        <nav className="toolbar">
+          <h3 className="book-title">{ this.props.bookTitle}</h3>
+          <ul className="actions">
+            <li><a className={this.props.inLiveMode ? 'active' : '' } onClick={this.props.toggleLiveMode}><i className="fa fa-columns"></i> Live Mode</a></li>
+            <li><a className={this.props.inLiveMode ? 'disabled' : ''} onClick={this.props.onGeneratePreview}><i className="fa fa-play"></i> Preview</a></li>
+          </ul>
+        </nav>
+      );
+    } else {
+      return (
+        <span />
+      );
+    }
   }
 }
 
 Toolbar.propTypes = {
+  enablePreview: React.PropTypes.bool.isRequired,
   inLiveMode: React.PropTypes.bool.isRequired,
   toggleLiveMode: React.PropTypes.func.isRequired,
   onGeneratePreview: React.PropTypes.func.isRequired,

--- a/src/markuapad.js
+++ b/src/markuapad.js
@@ -11,7 +11,8 @@ import FileAccessor from "./file_accessor";
 _.string = _string;
 
 let DEFAULT_OPTIONS = {
-  CHANGED_INTERVAL: 100
+  CHANGED_INTERVAL: 100,
+  enablePreview: true
 }
 
 class Markuapad {

--- a/src/web.js
+++ b/src/web.js
@@ -1,4 +1,4 @@
 import Markuapad from "./markuapad"
 
 // Call the api to create a new markuapad instance on the #main element
-Markuapad.create("main", { fileAccessor: ExampleFileAccessor, CHANGED_INTERVAL: 100 });
+Markuapad.create("main", { fileAccessor: ExampleFileAccessor, CHANGED_INTERVAL: 100, enablePreview: true });


### PR DESCRIPTION
1) With one extra flag, we can now disable the live mode and previewing. This allows us to just use markua pad as a text editor.

2) Added an extra step to the readme.

3) Fixed a react warning about prop missing in `Preview` render from `Main`
